### PR TITLE
Fix qt5 Concurrency package dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ find_package(Qt5 REQUIRED COMPONENTS
     Core
     Widgets
     Xml
-    Svg )
+    Svg
+    Concurrent
+    )
 
 include_directories(
     ${Qt5Core_INCLUDE_DIRS}
@@ -31,7 +33,8 @@ set(QT_LIBRARIES
     Qt5::Core
     Qt5::Widgets
     Qt5::Xml
-    Qt5::Svg )
+    Qt5::Svg
+    Qt5::Concurrent)
 
 add_definitions( ${QT_DEFINITIONS} -DQT_PLUGIN )
 set( PJ_LIBRARIES ${QT_LIBRARIES} )


### PR DESCRIPTION
When building in ROS2 Galactic, I found an issue with the QT5 Concurrency Module 

```
--- stderr: plotjuggler_apbin_plugins                        
CMake Error at CMakeLists.txt:82 (add_library):
  Target "DataAPBin" links to target "Qt5::Concurrent" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Generate step failed.  Build files cannot be regenerated correctly.
make: *** [Makefile:310: cmake_check_build_system] Error 1
---
Failed   <<< plotjuggler_apbin_plugins [4.00s, exited with code 2]
```

So I added it and it builds.