### PR TITLE
Added Docker builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ set(QT_LIBRARIES
 add_definitions( ${QT_DEFINITIONS} -DQT_PLUGIN )
 set( PJ_LIBRARIES ${QT_LIBRARIES} )
 
+#-------------- Switch units support ----------------
+OPTION(ADD_UNITS "Add units support" OFF)
+IF(ADD_UNITS)
+    add_compile_definitions("LABEL_WITH_UNIT")
+    message(STATUS "Enabling field units define.")
+ENDIF(ADD_UNITS)
+
 #--------------------------------------------------------
 #-------------- Build with CATKIN (ROS1) ----------------
 if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE} AS build-stage
+
+ARG PJ_TAG=3.9.2
+
+###############################################################################
+# Install dependencies.
+###############################################################################
+# General dependencies.
+RUN apt update && apt install -y build-essential cmake git 
+# PlotJuggler dependencies.
+RUN apt update && apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev \
+    libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq3-dev \
+    liblz4-dev libzstd-dev
+
+###############################################################################
+# Compile PlotJuggler
+###############################################################################
+WORKDIR /plotjuggler_ws/src
+RUN git clone --depth 1 --branch ${PJ_TAG} https://github.com/facontidavide/PlotJuggler.git PlotJuggler
+# Build PlotJuggler. This will take a long time.
+WORKDIR /plotjuggler_ws
+RUN cmake -S src/PlotJuggler -B build/PlotJuggler -DCMAKE_INSTALL_PREFIX=install \
+    && cmake --build build/PlotJuggler --config RelWithDebInfo --target install
+
+###############################################################################
+# Compile the plugin
+###############################################################################
+ARG ADD_UNITS=OFF
+
+COPY --link . /apbin_plugin
+WORKDIR /apbin_plugin/build
+# Ensure a fresh build folder
+RUN rm -R * \
+    && cmake -Dplotjuggler_DIR="/plotjuggler_ws/install/lib/cmake/plotjuggler" -DADD_UNITS=${ADD_UNITS} .. \
+    && make \
+    && make install \
+    && mkdir /artifacts \
+    && cp libDataAPBin.so /artifacts
+
+###############################################################################
+# Export the plugin
+###############################################################################
+FROM scratch AS export-stage
+# Move the plugin to a fresh filesystem that can be exported easily.
+COPY --from=build-stage /artifacts /

--- a/README.md
+++ b/README.md
@@ -1,33 +1,63 @@
 # plotjuggler-apbin-plugins
 
-This repository contains [ArduPilot Dataflash](https://ardupilot.org/copter/docs/common-logs.html) plugin for [PlotJuggler](https://github.com/facontidavide/PlotJuggler).
+This repository contains the [ArduPilot Dataflash](https://ardupilot.org/copter/docs/common-logs.html) plugin for [PlotJuggler](https://github.com/facontidavide/PlotJuggler).
 
+:construction: While you should be able to compile the plugin for Windows, this guide is tested for an Ubuntu workflow.
 
 ## Install PlotJuggler
 
 To build any plugin for PlotJuggler, PlotJuggler must be installed on your system.
-For detailled instructions on how to install PlotJuggler please have a look at the [Installation](https://github.com/facontidavide/PlotJuggler#installation) section of the PlotJuggler repository.
+For detailed instructions on how to install PlotJuggler please have a look at the [Installation](https://github.com/facontidavide/PlotJuggler#installation) section of the PlotJuggler repository.
 
 If you have ROS installed, you can install PlotJuggler using:
 
     sudo apt install ros-$ROS_DISTRO-plotjuggler-ros
 
+## (Optional) Build plotjuggler-apbin-plugin
 
-## Install plotjuggler-apbin-plugin
-The installation of the plotjuggler-apbin-plugin is straightforward.
+If you wish to build `plotjuggler-apbin-plugin` follow these steps.
 
-1. Clone the repository:
+### 1. Clone the repository
 
-    ```
-    git clone https://github.com/khancyr/plotjuggler-apbin-plugins
-    ```
+```
+git clone https://github.com/ArduPilot/plotjuggler-apbin-plugins
+```
     
-2. Install the dependencies:  
+### 2a. Compile via Docker
+
+This requires that you have Docker installed in your system.
+
+1. `cd` into the cloned repository.
+
+2. Prepare a new folder with
+    ```bash
+    mkdir artifacts
+    ```
+
+3. Build the plugin with
+    ```bash
+    docker build -o type=local,dest=artifacts .
+    ```
+    This command will clone and build PlotJuggler anew, which takes a lot of time.
+
+    You can pass build arguments with the `--build-arg` option.
+    Build arguments include:
+    - `ADD_UNITS[=OFF]`: Set to `ON` to enable the display of units in the logged fields. Read at the end for more information.
+    - `BASE_IMAGE[=ubuntu:22.04]`: Specify the OS image to build off of. It is known that using a different OS than your host OS may result in the plugin not working.
+    - `PJ_TAG[=3.9.2]`: The PlotJuggler git branch or tag to use when cloing and compiling PlotJuggler.
+
+Once compilation is finished, you will find your `.so` plugin in the `artifacts` folder you created previously.
+
+### 2b. Compile locally
+
+1. Install the dependencies:  
     The plugin uses Qt as dependency. Since PlotJuggler also depends on Qt, chances are high that you already have it installed. On Ubuntu Qt can be installed with:
 
     ```
     sudo apt -y install qtbase5-dev libqt5svg5-dev
     ```
+
+2. If you want the units to be displayed in PlotJuggler (read at the end), you need to edit `dataload_apbin.cpp` and activate `#define LABEL_WITH_UNIT`.  
 
 3. Compile using cmake:
 
@@ -38,13 +68,33 @@ The installation of the plotjuggler-apbin-plugin is straightforward.
     sudo make install
     ```
 
-If you run `sudo make install` the plugin gets installed to `/usr/local/bin/`.  
-Remember that PlotJuggler needs to find the plugin files at startup. Therefore make sure that the folder containing the plugin files is added to PlotJuggler in the settings.
-Check **App->Preferences->Plugins** in PlotJuggler to learn more.
+## Install plotjuggler-apbin-plugin
 
+PlotJuggler looks for plugins in specific folders. 
+Check **App->Preferences->Plugins** in PlotJuggler to find out which they are and add more if you wish to.
 
-## Configuration
-If you want the units to be displayed in PlotJuggler, you need to edit `dataload_apbin.cpp` and activate `#define LABEL_WITH_UNIT`.  
+If you have added a folder, you will need to restart PlotJuggler for the chage to take effect.
+
+### For prebuilt binaries
+
+You can find a pre-built plugin for Ubuntu in the [Github Releases](https://github.com/ArduPilot/plotjuggler-apbin-plugins/releases) page.
+Copy that binary to one of the PlotJuggler plugin folders.
+
+### For Docker-built binaries
+
+If you used Docker to compile the plugin, copy the build artifact from the `artifacts` folder to one of the PlotJuggler plugin folders.
+
+### For locally-built binaries
+
+If you compiled the plugin in your host system, the plugin has been installed to `/usr/local/bin/`.  
+
+Ensure that PlotJuggler scans for plugins in this folder or copy the plugin in one of the folders PlotJuggler already scans.
+
+## Displaying units
+
+This plugin allows the units of logged fields to be appended to the logged field names.
+
 **Be carefull:**  
-This is not a nice solution because the units are simply appended to the field names.
-This renders your already created visualization layouts unusable. It would be a better solution if PlotJuggler supported unit handling directly.
+
+If you created a PlotJuggler layout without units and then enable the units, the layout will be unusable and vice-versa.
+This is because the units are part of the field name; hence, the original field name no longer exists.


### PR DESCRIPTION
This PR adds support for building the plugin via Docker.
This will make building a lot more consistent.

Docker flags are added to select:
- Base OS
- PlotJuggler tag
- Field units ON/OFF compile switch

Currently only Ubuntu is supported.

I'm envisioning we can add a few pre-built binaries in a Github release. I have added a link to the Readme for that.

In the future, if we want, we can probably also make this automated for every new version tag, with Github Actions.