### PR TITLE
windows compatibily and github action build

### DIFF
--- a/.github/workflows/win_build.yml
+++ b/.github/workflows/win_build.yml
@@ -1,0 +1,66 @@
+name: Build PlotJuggler & Plugin
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout plugin
+      uses: actions/checkout@v4
+
+    - name: Install Conan
+      uses: turtlebrowser/get-conan@main
+
+    - name: Install Qt (se serve)
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '5.15.2'
+        arch: 'win64_msvc2019_64'
+
+    # (Facoltativo, se usi la cache Conan)
+    - name: Cache Conan
+      uses: actions/cache@v4
+      with:
+        path: ~/.conan2/
+        key: ${{ runner.os }}-conan-${{ hashFiles('**/conanfile.txt') }}
+
+    # Conan install per il plugin
+    - name: Conan install
+      shell: pwsh
+      run: |
+        conan profile detect
+        conan install . -of build --build=missing -pr:b=default -s build_type=Release
+
+    - name: Cache PlotJuggler install
+      uses: actions/cache@v4
+      with:
+        path: pj_install/
+        key: ${{ runner.os }}-plotjuggler-${{ hashFiles('plotjuggler/**') }}
+
+    - name: Clone PlotJuggler
+      run: git clone --depth 1 --branch 3.9.2 https://github.com/facontidavide/PlotJuggler.git plotjuggler
+
+    - name: Build & install PlotJuggler (se non in cache)
+      if: steps.cache-plotjuggler.outputs.cache-hit != 'true'
+      run: |
+        mkdir pj_build
+        cmake -S plotjuggler -B pj_build -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\pj_install -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake --build pj_build --config RelWithDebInfo --target install
+
+    - name: Build your plugin
+      run: |        
+        Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
+        mkdir build
+        cd build
+        cmake .. -Dplotjuggler_DIR="${{ github.workspace }}\pj_install\lib\cmake\plotjuggler" -DADD_UNITS=OFF
+        cmake --build . --config Release
+        cmake --install . --prefix "${{ github.workspace }}\plugin_install"
+
+    # (Opzionale) Carica come artifact il risultato della build
+    - name: Upload plugin artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: plugin-build
+        path: build/

--- a/.github/workflows/win_build.yml
+++ b/.github/workflows/win_build.yml
@@ -13,20 +13,18 @@ jobs:
     - name: Install Conan
       uses: turtlebrowser/get-conan@main
 
-    - name: Install Qt (se serve)
+    - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
         version: '5.15.2'
         arch: 'win64_msvc2019_64'
 
-    # (Facoltativo, se usi la cache Conan)
     - name: Cache Conan
       uses: actions/cache@v4
       with:
         path: ~/.conan2/
         key: ${{ runner.os }}-conan-${{ hashFiles('**/conanfile.txt') }}
 
-    # Conan install per il plugin
     - name: Conan install
       shell: pwsh
       run: |
@@ -42,7 +40,7 @@ jobs:
     - name: Clone PlotJuggler
       run: git clone --depth 1 --branch 3.9.2 https://github.com/facontidavide/PlotJuggler.git plotjuggler
 
-    - name: Build & install PlotJuggler (se non in cache)
+    - name: Build & install PlotJuggler
       if: steps.cache-plotjuggler.outputs.cache-hit != 'true'
       run: |
         mkdir pj_build
@@ -58,7 +56,7 @@ jobs:
         cmake --build . --config Release
         cmake --install . --prefix "${{ github.workspace }}\plugin_install"
 
-    # (Opzionale) Carica come artifact il risultato della build
+
     - name: Upload plugin artifact
       uses: actions/upload-artifact@v4
       with:

--- a/DataLoadAPBin/dataload_apbin.cpp
+++ b/DataLoadAPBin/dataload_apbin.cpp
@@ -21,6 +21,7 @@
 #include <QDebug>
 #include <chrono>
 #include <cmath>
+#include <array>
 
 
 // Debugging 

--- a/DataLoadAPBin/logformat.h
+++ b/DataLoadAPBin/logformat.h
@@ -14,6 +14,13 @@
 #pragma once
 #include <cstdint>
 
+// PACKED_STRUCT macro cross-platform
+#ifdef _MSC_VER
+  #define PACKED_STRUCT(definition) __pragma(pack(push, 1)) definition __pragma(pack(pop))
+#else
+  #define PACKED_STRUCT(definition) definition __attribute__((packed))
+#endif
+
 
 /*
 The contents of this file were mainly taken from the ArduPilot source code:
@@ -125,6 +132,7 @@ static constexpr uint8_t MAX_MULTIPLIERS_SIZE = 17-1;   // max 16 fields per mes
     - file: libraries/AP_Logger/LogStructure.h (commit: b80cc9a)
     - line: 160 - 167
 */
+PACKED_STRUCT(
 struct log_Format {
   LOG_PACKET_HEADER;
   uint8_t type;                   // message id
@@ -132,7 +140,7 @@ struct log_Format {
   char name[MAX_NAME_SIZE];       // message name           example: "PIDR"
   char format[MAX_FORMAT_SIZE];   // format                 example: "QfffffffffB"
   char labels[MAX_LABELS_SIZE];   // label (field names)    example: "TimeUS,Tar,Act,Err,P,I,D,FF,Dmod,SRate,Limit"
-} __attribute__((packed));
+});
 
 
 
@@ -143,10 +151,11 @@ struct log_Format {
     - file: libraries/AP_Logger/LogStructure.h (commit: b80cc9a)
     - line: 183 - 188
 */
+PACKED_STRUCT(
 struct log_Format_Units {
   LOG_PACKET_HEADER;
   uint64_t time_us;
   uint8_t format_type;
   char units[MAX_UNITS_SIZE];               // units        example: "s----------"
   char multipliers[MAX_MULTIPLIERS_SIZE];   // multipliers  example: "F----------"
-} __attribute__((packed));
+});

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,12 @@
+ [requires]
+ protobuf/3.21.12
+ mosquitto/2.0.18
+ zeromq/4.3.5
+ zlib/1.2.13
+
+ [options]
+ zeromq*:shared=False
+
+ [generators]
+ CMakeDeps
+ CMakeToolchain


### PR DESCRIPTION
This PR modified the plugin to have windows compatibility.

Using github action pipeline, the library il build automatically and the artifact is automatically created, ready to be used as PJ plugin.