### PR TITLE
Add CI win build with units

### DIFF
--- a/.github/workflows/win_build.yml
+++ b/.github/workflows/win_build.yml
@@ -47,7 +47,7 @@ jobs:
         cmake -S plotjuggler -B pj_build -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\pj_install -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build pj_build --config RelWithDebInfo --target install
 
-    - name: Build your plugin
+    - name: Build the plugin without unit names
       run: |        
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
         mkdir build
@@ -60,5 +60,21 @@ jobs:
     - name: Upload plugin artifact
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-build
-        path: build/
+        name: DataAPBin_no_units
+        path: build/Release/DataAPBin.dll
+
+    - name: Build the plugin with unit names
+      run: |        
+        Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
+        mkdir build
+        cd build
+        cmake .. -Dplotjuggler_DIR="${{ github.workspace }}\pj_install\lib\cmake\plotjuggler" -DADD_UNITS=ON
+        cmake --build . --config Release
+        cmake --install . --prefix "${{ github.workspace }}\plugin_install"
+
+
+    - name: Upload plugin artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: DataAPBin_with_units
+        path: build/Release/DataAPBin.dll

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This requires that you have Docker installed in your system.
     Build arguments include:
     - `ADD_UNITS[=OFF]`: Set to `ON` to enable the display of units in the logged fields. Read at the end for more information.
     - `BASE_IMAGE[=ubuntu:22.04]`: Specify the OS image to build off of. It is known that using a different OS than your host OS may result in the plugin not working.
-    - `PJ_TAG[=3.9.2]`: The PlotJuggler git branch or tag to use when cloing and compiling PlotJuggler.
+    - `PJ_TAG[=3.9.2]`: The PlotJuggler git branch or tag to use when cloning and compiling PlotJuggler.
 
 Once compilation is finished, you will find your `.so` plugin in the `artifacts` folder you created previously.
 


### PR DESCRIPTION
Both .dll files should be uploaded in the artifacts of the build.