### PR TITLE
fix(cmake): register package via ament_package() in ROS 2 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,7 @@ install(
         DataAPBin
     DESTINATION
         ${PJ_PLUGIN_INSTALL_DIRECTORY}  )
+
+if (COMPILING_WITH_AMENT)
+    ament_package()
+endif()


### PR DESCRIPTION
## Summary

Call `ament_package()` at the end of the ament-cmake branch so the package registers itself on `AMENT_PREFIX_PATH` when sourcing the colcon workspace's `install/setup.bash`.

## Problem

The ament branch sets `COMPILING_WITH_AMENT`, finds `ament_cmake`/`plotjuggler`, and installs the `.so`, but never calls `ament_package()`. Without it, colcon doesn't emit `local_setup.bash` and the package never lands on `AMENT_PREFIX_PATH`. Downstream tools that walk `AMENT_PREFIX_PATH` to discover plugins (e.g. PlotJuggler [#1374](https://github.com/facontidavide/PlotJuggler/pull/1374)) can't find the `.so` even though it's installed. The catkin branch already calls `catkin_package()` on line 52; this restores parity.

## Solution

Add `ament_package()` after the install rule, gated on `COMPILING_WITH_AMENT` so it's a no-op for catkin and bare-cmake builds.

**Sponsored by ARK Electronics**