### PR TITLE
fix(loader): reset per-load state so msg_ids don't leak between logs

### DIFF
--- a/DataLoadAPBin/dataload_apbin.cpp
+++ b/DataLoadAPBin/dataload_apbin.cpp
@@ -61,6 +61,25 @@ const std::vector<const char*>& DataLoadAPBIN::compatibleFileExtensions() const
 
 bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data)
 {
+  // Reset all per-load state. Without this, member variables persist across
+  // file loads in the same PlotJuggler session: stale has_instance / instance_offset
+  // entries from a previous log get applied to the current one whenever ArduPilot
+  // recycles a msg_id, producing bogus per-instance topics (e.g. HEAT split into
+  // dozens of "#N" children) and skewed timestamps from re-applied multipliers.
+  std::fill(std::begin(has_fmt), std::end(has_fmt), false);
+  std::fill(std::begin(has_fmtu), std::end(has_fmtu), false);
+  std::fill(std::begin(has_instance), std::end(has_instance), false);
+  std::fill(std::begin(instance_idx), std::end(instance_idx), -1);
+  std::fill(std::begin(instance_offset), std::end(instance_offset), 0u);
+  for (auto& f : formats) { f = {}; }
+  for (auto& fu : format_units) { fu = {}; }
+  for (auto& n : msg_id2name) { n.clear(); }
+  msg_name2id.clear();
+  field_name2idx.clear();
+  messages_map.clear();
+  multipliers.clear();
+  units.clear();
+
   QFile file(info->filename);
   if (!file.open(QFile::ReadOnly))
   {


### PR DESCRIPTION
## Summary

All parser bookkeeping (`has_fmt` / `has_fmtu` / `has_instance` / `instance_idx` / `instance_offset` / `formats` / `format_units` / `msg_id2name` / `msg_name2id` / `field_name2idx` / `messages_map` / `multipliers` / `units`) lives in `DataLoadAPBIN` member variables, but the plugin instance is reused for every file load in a session and `readDataFromFile` never reset any of them. This patch clears them at the top of `readDataFromFile`.

## Problem

ArduPilot assigns msg_ids dynamically per boot, so loading two logs in sequence can put a different message at the same id. The FMTU handler guards the `#` check with `if (!has_instance[msg_id])`, so a stale `true` from a previous file's message is never re-evaluated. When the next log puts a non-instanced message at that id, it gets treated as instanced and a byte from its payload (at the previous file's `instance_offset`) is read as the instance number.

Reproducer using two real ArduPilot logs from the same vehicle (one had msg_id 251 = SURF, the next had msg_id 251 = HEAT):

```
Before fix:
  After loading log_A.bin (msg_id 251 == SURF):
    HEAT series count: 5
  After loading log_B.bin (msg_id 251 == HEAT):
    HEAT series count: 308       <-- spurious /HEAT/#-102/...,
                                     /HEAT/#-105/..., etc.

After fix:
  After loading log_A.bin:  HEAT series count: 5
  After loading log_B.bin:  HEAT series count: 5
```

The accumulated `messages_map` also causes timestamps that already went through `apply_multipliers` + `apply_timesync` to be re-processed on the next load, producing far-future stray data points that compress the plot's useful range against one edge.

## Solution

`std::fill` the bool/int arrays, value-initialize the `log_Format` / `log_Format_Units` structs, clear the strings in `msg_id2name`, and call `.clear()` on the maps. Verified the fix by loading the same two-log sequence via `QPluginLoader` and dumping the resulting `PlotDataMapRef`.