### PR TITLE
Taking first valid GPS message for time sync

### DIFF
--- a/.github/workflows/win_build.yml
+++ b/.github/workflows/win_build.yml
@@ -4,8 +4,8 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: windows-latest
-    
+    runs-on: windows-2022
+
     steps:
     - name: Checkout plugin
       uses: actions/checkout@v4
@@ -29,33 +29,39 @@ jobs:
       shell: pwsh
       run: |
         conan profile detect
-        conan install . -of build --build=missing -pr:b=default -s build_type=Release
+        conan install . -of build --build=missing -pr:b=default `
+          -s build_type=Release -s compiler.cppstd=20 `
+          -c tools.build:jobs=$([Environment]::ProcessorCount) `
+          -c tools.cmake.cmaketoolchain:generator=Ninja
 
     - name: Cache PlotJuggler install
+      id: cache-plotjuggler
       uses: actions/cache@v4
       with:
         path: pj_install/
         key: ${{ runner.os }}-plotjuggler-${{ hashFiles('plotjuggler/**') }}
 
     - name: Clone PlotJuggler
+      if: steps.cache-plotjuggler.outputs.cache-hit != 'true'
       run: git clone --depth 1 --branch 3.9.2 https://github.com/facontidavide/PlotJuggler.git plotjuggler
 
     - name: Build & install PlotJuggler
       if: steps.cache-plotjuggler.outputs.cache-hit != 'true'
+      shell: pwsh
       run: |
         mkdir pj_build
         cmake -S plotjuggler -B pj_build -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\pj_install -DCMAKE_BUILD_TYPE=RelWithDebInfo
-        cmake --build pj_build --config RelWithDebInfo --target install
+        cmake --build pj_build --config RelWithDebInfo --target install --parallel $([Environment]::ProcessorCount)
 
     - name: Build your plugin
-      run: |        
+      shell: pwsh
+      run: |
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
         mkdir build
         cd build
         cmake .. -Dplotjuggler_DIR="${{ github.workspace }}\pj_install\lib\cmake\plotjuggler" -DADD_UNITS=OFF
-        cmake --build . --config Release
+        cmake --build . --config Release --parallel $([Environment]::ProcessorCount)
         cmake --install . --prefix "${{ github.workspace }}\plugin_install"
-
 
     - name: Upload plugin artifact
       uses: actions/upload-artifact@v4

--- a/DataLoadAPBin/dataload_apbin.cpp
+++ b/DataLoadAPBin/dataload_apbin.cpp
@@ -23,17 +23,14 @@
 #include <cmath>
 #include <array>
 
-
 // Debugging 
 //#define DEBUG_RUNTIME
 //#define DEBUG_MESSAGES
 //#define DEBUG_MULTIPLIERS
 //#define DEBUG_UNITS
 
-
 // Config
 //#define LABEL_WITH_UNIT
-
 
 bool is_nearly(double val, int val2)
 {
@@ -47,7 +44,6 @@ bool is_nearly(double val, int val2)
     return false;
   }
 }
-
 
 DataLoadAPBIN::DataLoadAPBIN()
 {
@@ -158,7 +154,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
 
     // get message-id from header
     const uint8_t type = buf[total_bytes_used + 2];
-
 
     // -------------------- handle FMT-message -------------------- //
     if (type == LOG_FORMAT_MSG)
@@ -277,7 +272,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
       break;
     }
 
-
     // -------------------- handle FMTU-message -------------------- //
     if ( memcmp(fmt.name, "FMTU", 4) == 0 )
     {
@@ -290,7 +284,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
       has_fmtu[msg_id] = true;
       struct log_Format_Units& fmtu = format_units[msg_id];
       memcpy(&fmtu, &buf[total_bytes_used], sizeof(struct log_Format_Units));
-
 
       // handle instances
       //  - check if units contain "#" (see also: logformat.h)
@@ -326,7 +319,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
       continue;
     }
 
-
     // -------------------- handle MULT-message -------------------- //
     if ( memcmp(fmt.name, "MULT", 4) == 0 )
     {
@@ -354,7 +346,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
       continue;
     }
 
-
     // -------------------- handle UNIT-message -------------------- //
     if ( memcmp(fmt.name, "UNIT", 4) == 0 )
     {
@@ -381,7 +372,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
 
       continue;
     }
-
 
     // -------------------- handle any other message -------------------- //
 
@@ -427,7 +417,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
       other_ms += (other_end - other_start);
     #endif
   }
-
 
   // -------------------- process UNITs -------------------- //
   #ifdef DEBUG_RUNTIME
@@ -475,7 +464,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
     process_units_ms += (process_units_end - process_units_start);
   #endif
 
-
   // -------------------- apply multipliers -------------------- //
   #ifdef DEBUG_RUNTIME
     auto apply_mult_start = std::chrono::high_resolution_clock::now();
@@ -486,7 +474,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
     apply_mult_ms += (apply_mult_end - apply_mult_start);
   #endif
 
-
   // -------------------- apply timesync -------------------- //
   #ifdef DEBUG_RUNTIME
     auto apply_tsync_start = std::chrono::high_resolution_clock::now();
@@ -496,8 +483,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
     auto apply_tsync_end = std::chrono::high_resolution_clock::now();
     apply_tsync_ms += (apply_tsync_end - apply_tsync_start);
   #endif
-
-
 
   #ifdef DEBUG_MESSAGES
   std::printf("\n--------- DEBUG_MESSAGES ---------");
@@ -547,8 +532,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
   }
   std::printf("-------------- END --------------\n\n");
   #endif
-
-
 
   // -------------------- publish to plotjuggler -------------------- //
   #ifdef DEBUG_RUNTIME
@@ -659,10 +642,6 @@ bool DataLoadAPBIN::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_da
   return true;
 }
 
-
-
-
-
 void DataLoadAPBIN::handle_message_received(const struct log_Format& fmt, const uint8_t* msg)
 {
   // message id
@@ -695,7 +674,6 @@ void DataLoadAPBIN::handle_message_received(const struct log_Format& fmt, const 
 
   uint32_t msg_offset = LOG_PACKET_HEADER_LEN;  // discard header
 
-  
   /*
     If you need to change this section, please also fix logformat.h (format_types)!
     AP_Logger: Format Types (https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Logger#format-types)
@@ -802,8 +780,6 @@ void DataLoadAPBIN::handle_message_received(const struct log_Format& fmt, const 
   }
 }
 
-
-
 DataLoadAPBIN::message_data DataLoadAPBIN::create_message_data(const struct log_Format& fmt)
 {
   QString labelStr(fmt.labels);
@@ -822,8 +798,6 @@ DataLoadAPBIN::message_data DataLoadAPBIN::create_message_data(const struct log_
   }
   return msg_data;
 }
-
-
 
 uint32_t DataLoadAPBIN::get_field_byte_offset(const uint8_t& msg_id, const uint8_t& field_idx)
 {
@@ -863,8 +837,6 @@ uint32_t DataLoadAPBIN::get_field_byte_offset(const uint8_t& msg_id, const uint8
   return total_offset;
 }
 
-
-
 uint32_t DataLoadAPBIN::get_field_byte_offset(const uint8_t& msg_id, const std::string& field_name)
 {
   const std::string& msg_name = msg_id2name[msg_id];
@@ -872,8 +844,6 @@ uint32_t DataLoadAPBIN::get_field_byte_offset(const uint8_t& msg_id, const std::
 
   return get_field_byte_offset(msg_id, field_idx);
 }
-
-
 
 uint8_t DataLoadAPBIN::get_instance(const struct log_Format& fmt, const uint8_t* msg)
 {
@@ -891,8 +861,6 @@ uint8_t DataLoadAPBIN::get_instance(const struct log_Format& fmt, const uint8_t*
 
   return instance;
 }
-
-
 
 std::string DataLoadAPBIN::get_unit(const std::string& msg_name, const std::string& field_name)
 {
@@ -922,8 +890,6 @@ std::string DataLoadAPBIN::get_unit(const std::string& msg_name, const std::stri
 
   return unit_it->second;
 }
-
-
 
 void DataLoadAPBIN::apply_multipliers(void)
 {
@@ -979,70 +945,155 @@ void DataLoadAPBIN::apply_multipliers(void)
 }
 
 
+double DataLoadAPBIN::gps_to_unix_time(double gps_week, double gps_ms_of_week)
+{
+    static constexpr double SECONDS_PER_WEEK       = 60 * 60 * 24 * 7;   // 60 * 60 * 24 * 7
+    static constexpr double MS_PER_SECOND          = 1000.0;
+    static constexpr double GPS2UNIX_TIME_OFFSET   = 315964800.0; // Unix epoch vs GPS epoch
+    static constexpr double GPS2UNIX_LEAP_SECONDS  = -18.0;       // Current leap seconds
+
+    const double gps_week_seconds = gps_ms_of_week / MS_PER_SECOND;
+
+    return (gps_week * SECONDS_PER_WEEK)
+         + gps_week_seconds
+         + GPS2UNIX_TIME_OFFSET
+         + GPS2UNIX_LEAP_SECONDS;
+}
 
 void DataLoadAPBIN::apply_timesync(void)
 {
-  // ArduPilot logs should be comparable with rosbags, therefore the same time basis is needed...
-  //  - rosbag:         unix time
-  //  - ArduPilot log:  local time since power on
-  //    -> the logged GNSS time can be used for synchronisation
+  static constexpr double MIN_VALID_NSATS = 4;
 
-  // extract GNSS time
   const auto msg_it = messages_map.find("GPS");
-  if ( msg_it == messages_map.end() )
+  if (msg_it == messages_map.end() || msg_it->second.empty())
   {
     std::printf("Skipping timesync because the logfile does not contain GNSS data\n");
     return;
   }
 
-  // take the first instance as reference
-  // todo: change that?
-  const message_data& gps_msg_data = messages_map["GPS"][0];
+  // Target the first available GPS instance (typically Instance 0)
+  const auto& first_gps_instance = msg_it->second.begin()->second;
 
-  // counter
-  int idx;
-  
-  // get needed field indexes
-  const auto& gps_time_idx = field_name2idx["GPS"]["TimeUS"];
-  const auto& gps_week_idx = field_name2idx["GPS"]["GWk"]; // GWk -> GPS week
-  const auto& gps_ms_idx = field_name2idx["GPS"]["GMS"];   // GMS -> GPS seconds in week (ms)
-
-  // constant time offset variables
-  static constexpr double GPS2UNIX_TIME_OFFSET = 315964800;   // time offset between unix and gps time
-  static constexpr double GPS2UNIX_LEAP_SECONDS = -18;        // additional time offset due to leap seconds (must be adjusted if number of leap seconds changes!)
-  static constexpr double SECONDS_PER_WEEK = 604800;          // number of seconds per week
-
-  const double& gps_week = gps_msg_data[gps_week_idx].second[1];
-  const double gps_week_seconds = gps_msg_data[gps_ms_idx].second[1] * 0.001;
-
-  const double unix_time = gps_week * SECONDS_PER_WEEK + gps_week_seconds + GPS2UNIX_TIME_OFFSET + GPS2UNIX_LEAP_SECONDS;
-
-  const double& log_time = gps_msg_data[gps_time_idx].second[1];
-
-  const double time_offset = unix_time - log_time;
-
-
-  // iterate through messages
-  for (auto& msg_it : messages_map)
+  // Safely look up the GPS field-name -> index map first
+  const auto gps_fields_it = field_name2idx.find("GPS");
+  if (gps_fields_it == field_name2idx.end())
   {
-    const auto& msg_name = msg_it.first;
+    std::printf("Skipping timesync because the logfile has no field definitions for 'GPS'\n");
+    return;
+  }
+  const auto& gps_fields = gps_fields_it->second;
 
-    auto time_idx_it = field_name2idx[msg_name].find("TimeUS");
-    if (time_idx_it == field_name2idx[msg_name].end())
+  // Safely resolve each required field index, bailing out with a clear
+  // error if any label is missing instead of silently defaulting to 0
+  // (which is what operator[] on a std::map would otherwise do).
+  auto require_field = [&](const std::string& label, uint8_t& out_idx) -> bool
+  {
+    const auto it = gps_fields.find(label);
+    if (it == gps_fields.end())
+    {
+      std::printf("Skipping timesync because GPS message has no '%s' field!\n", label.c_str());
+      return false;
+    }
+    out_idx = it->second;
+    return true;
+  };
+
+  uint8_t time_idx{ 0 };
+  uint8_t week_idx{ 0 };
+  uint8_t ms_idx{ 0 };
+  uint8_t nsats_idx{ 0 };
+
+  if (!require_field("TimeUS", time_idx)  ||
+      !require_field("GWk",    week_idx)  ||
+      !require_field("GMS",    ms_idx)    ||
+      !require_field("NSats",  nsats_idx))
+  {
+    return;
+  }
+
+  // Extract the actual vectors of logged data points
+  const auto& time_vec  = first_gps_instance.at(time_idx).second;
+  const auto& week_vec  = first_gps_instance.at(week_idx).second;
+  const auto& ms_vec    = first_gps_instance.at(ms_idx).second;
+  const auto& nsats_vec = first_gps_instance.at(nsats_idx).second;
+
+  // DEBUG: confirm units of time_vec before trusting any conversion assumption.
+  // If these print as small fractional numbers (e.g. 45.231), TimeUS is already
+  // in seconds after apply_multipliers() ran. If they print as huge raw integers
+  // (e.g. 45231000), TimeUS is still in microseconds at this point.
+  if (!time_vec.empty())
+  {
+    std::printf("DEBUG: raw time_vec.front()=%.6f time_vec.back()=%.6f\n",
+                time_vec.front(), time_vec.back());
+  }
+
+  size_t valid_sample_idx = 0;
+  bool found_valid_fix = false;
+
+  // Loop THROUGH THE TIMELINE of logged GPS samples
+  for (size_t i = 0; i < time_vec.size(); ++i)
+  {
+    if (i < nsats_vec.size() && i < week_vec.size() && i < ms_vec.size() &&
+        nsats_vec[i] >= MIN_VALID_NSATS &&   // relaxed to >=
+        time_vec[i]  != 0.0 &&               // added missing check
+        week_vec[i]  > 0.0 &&
+        ms_vec[i]    > 0.0)
+    {
+      valid_sample_idx = i;
+      found_valid_fix = true;
+      break;
+    }
+  }
+
+  if (!found_valid_fix)
+  {
+    std::printf("Skipping timesync because no sequential GPS sample with a valid fix was found\n");
+    return;
+  }
+
+  // Extract values at the valid chronological index found
+  const double gps_week    = week_vec[valid_sample_idx];
+  const double gps_week_ms = ms_vec[valid_sample_idx];
+
+  // TimeUS is already in SECONDS by this point, because apply_multipliers()
+  // runs before apply_timesync() and rescales TimeUS using its FMTU multiplier
+  // (commonly 0.000001, converting raw microseconds to seconds). Dividing by
+  // 1e6 again here was the bug that collapsed the whole log into a
+  // sub-one-second time range.
+  const double log_time_sec = time_vec[valid_sample_idx];
+
+  // Get Unix time directly in SECONDS (e.g., 1750692063.6)
+  const double unix_time_sec = gps_to_unix_time(gps_week, gps_week_ms);
+
+  // Calculate offset purely in SECONDS
+  const double time_offset_sec = unix_time_sec - log_time_sec;
+
+  std::printf("DEBUG: idx=%zu gps_week=%.3f gps_week_ms=%.3f log_time_sec=%.6f unix_time_sec=%.3f offset=%.3f\n",
+              valid_sample_idx, gps_week, gps_week_ms, log_time_sec, unix_time_sec, time_offset_sec);
+
+  // Apply the offset to every message's TimeUS vector (already in seconds)
+  for (auto& [msg_name, instances_map] : messages_map)
+  {
+    const auto msg_fields_it = field_name2idx.find(msg_name);
+    if (msg_fields_it == field_name2idx.end())
     {
       continue;
     }
-    auto& time_idx = time_idx_it->second;
 
-    // iterate through instances
-    auto& instances_map = msg_it.second;
-    for (auto& inst_it : instances_map)
+    const auto time_idx_it = msg_fields_it->second.find("TimeUS");
+    if (time_idx_it == msg_fields_it->second.end())
     {
-      // add time offset
-      message_data& msg_data = inst_it.second;
+      continue;
+    }
+    const auto& msg_time_idx = time_idx_it->second;
 
-      std::vector<double>& timestamps = msg_data[time_idx].second;
-      std::transform(timestamps.begin(), timestamps.end(), timestamps.begin(), std::bind(std::plus<double>(), std::placeholders::_1, time_offset));
+    for (auto& [instance_id, msg_data] : instances_map)
+    {
+      std::vector<double>& timestamps = msg_data[msg_time_idx].second;
+
+      // No conversion needed here anymore — just shift by the computed offset
+      std::transform(timestamps.begin(), timestamps.end(), timestamps.begin(),
+                      [time_offset_sec](double t) { return t + time_offset_sec; });
     }
   }
 }

--- a/DataLoadAPBin/dataload_apbin.cpp
+++ b/DataLoadAPBin/dataload_apbin.cpp
@@ -947,10 +947,10 @@ void DataLoadAPBIN::apply_multipliers(void)
 
 double DataLoadAPBIN::gps_to_unix_time(double gps_week, double gps_ms_of_week)
 {
-    static constexpr double SECONDS_PER_WEEK       = 60 * 60 * 24 * 7;   // 60 * 60 * 24 * 7
-    static constexpr double MS_PER_SECOND          = 1000.0;
-    static constexpr double GPS2UNIX_TIME_OFFSET   = 315964800.0; // Unix epoch vs GPS epoch
-    static constexpr double GPS2UNIX_LEAP_SECONDS  = -18.0;       // Current leap seconds
+    static constexpr double SECONDS_PER_WEEK      = 60 * 60 * 24 * 7;   // 60 * 60 * 24 * 7
+    static constexpr double MS_PER_SECOND         = 1000.0;
+    static constexpr double GPS2UNIX_TIME_OFFSET  = 315964800.0; // Unix epoch vs GPS epoch
+    static constexpr double GPS2UNIX_LEAP_SECONDS = -18.0;       // Current leap seconds
 
     const double gps_week_seconds = gps_ms_of_week / MS_PER_SECOND;
 
@@ -958,6 +958,116 @@ double DataLoadAPBIN::gps_to_unix_time(double gps_week, double gps_ms_of_week)
          + gps_week_seconds
          + GPS2UNIX_TIME_OFFSET
          + GPS2UNIX_LEAP_SECONDS;
+}
+
+namespace
+{
+
+  // Small struct to carry all four resolved GPS field indices together,
+  // instead of passing four separate uint8_t out-parameters around.
+  struct GpsFieldIndices
+  {
+    uint8_t time_idx;
+    uint8_t week_idx;
+    uint8_t ms_idx;
+    uint8_t nsats_idx;
+  };
+
+  // Resolves the index of each required GPS field by name.
+  // Returns std::nullopt (and prints a clear message) if any field is
+  // missing, instead of silently defaulting to index 0 via
+  // std::map::operator[].
+  std::optional<GpsFieldIndices> resolve_gps_field_indices(
+      const std::map<std::string, std::map<std::string, uint8_t>>& field_name2idx)
+  {
+    const auto gps_fields_it = field_name2idx.find("GPS");
+    if (gps_fields_it == field_name2idx.end())
+    {
+      std::printf("Skipping timesync because the logfile has no field definitions for GPS\n");
+      return std::nullopt;
+    }
+    const auto& gps_fields = gps_fields_it->second;
+
+    auto find_field = [&](const std::string& label) -> std::optional<uint8_t>
+    {
+      const auto it = gps_fields.find(label);
+      if (it == gps_fields.end())
+      {
+        std::printf("Skipping timesync because GPS message has no '%s' field!\n", label.c_str());
+        return std::nullopt;
+      }
+      return it->second;
+    };
+
+    const auto time_idx  = find_field("TimeUS");
+    const auto week_idx  = find_field("GWk");
+    const auto ms_idx    = find_field("GMS");
+    const auto nsats_idx = find_field("NSats");
+
+    if (!time_idx || !week_idx || !ms_idx || !nsats_idx)
+    {
+      return std::nullopt;
+    }
+
+    return GpsFieldIndices{ *time_idx, *week_idx, *ms_idx, *nsats_idx };
+  }
+
+  // Scans the logged GPS timeline for the first sample with a usable fix:
+  // enough satellites, and non-zero TimeUS/GWk/GMS. GWk in particular must be
+  // checked, since a sample can report NSats > 4 and non-zero TimeUS/GMS
+  // while GWk is still 0 (week number not yet resolved) - accepting that
+  // sample would anchor the whole log to the GPS epoch (1980-01-06).
+  std::optional<size_t> find_first_valid_gps_sample(
+      const std::vector<double>& time_vec,
+      const std::vector<double>& week_vec,
+      const std::vector<double>& ms_vec,
+      const std::vector<double>& nsats_vec,
+      double min_nsats)
+  {
+    for (size_t i = 0; i < time_vec.size(); ++i)
+    {
+      if (i < nsats_vec.size() && i < week_vec.size() && i < ms_vec.size() &&
+          nsats_vec[i] >= min_nsats &&
+          time_vec[i]  != 0.0 &&
+          week_vec[i]  > 0.0  &&
+          ms_vec[i]    > 0.0)
+      {
+        return i;
+      }
+    }
+    return std::nullopt;
+  }
+
+  void shift_all_timestamps(
+    std::map<std::string, std::map<int8_t,
+        std::vector<std::pair<std::string, std::vector<double>>>>>& messages_map,
+    const std::map<std::string, std::map<std::string, uint8_t>>& field_name2idx,
+    double time_offset_sec)
+  {
+    for (auto& [msg_name, instances_map] : messages_map)
+    {
+      const auto msg_fields_it = field_name2idx.find(msg_name);
+      if (msg_fields_it == field_name2idx.end())
+      {
+        continue;
+      }
+
+      const auto time_idx_it = msg_fields_it->second.find("TimeUS");
+      if (time_idx_it == msg_fields_it->second.end())
+      {
+        continue;
+      }
+      const auto& msg_time_idx = time_idx_it->second;
+
+      for (auto& [instance_id, msg_data] : instances_map)
+      {
+        std::vector<double>& timestamps = msg_data[msg_time_idx].second;
+        std::transform(timestamps.begin(), timestamps.end(), timestamps.begin(),
+                        [time_offset_sec](double t) { return t + time_offset_sec; });
+      }
+    }
+  }
+
 }
 
 void DataLoadAPBIN::apply_timesync(void)
@@ -974,126 +1084,33 @@ void DataLoadAPBIN::apply_timesync(void)
   // Target the first available GPS instance (typically Instance 0)
   const auto& first_gps_instance = msg_it->second.begin()->second;
 
-  // Safely look up the GPS field-name -> index map first
-  const auto gps_fields_it = field_name2idx.find("GPS");
-  if (gps_fields_it == field_name2idx.end())
-  {
-    std::printf("Skipping timesync because the logfile has no field definitions for 'GPS'\n");
-    return;
-  }
-  const auto& gps_fields = gps_fields_it->second;
-
-  // Safely resolve each required field index, bailing out with a clear
-  // error if any label is missing instead of silently defaulting to 0
-  // (which is what operator[] on a std::map would otherwise do).
-  auto require_field = [&](const std::string& label, uint8_t& out_idx) -> bool
-  {
-    const auto it = gps_fields.find(label);
-    if (it == gps_fields.end())
-    {
-      std::printf("Skipping timesync because GPS message has no '%s' field!\n", label.c_str());
-      return false;
-    }
-    out_idx = it->second;
-    return true;
-  };
-
-  uint8_t time_idx{ 0 };
-  uint8_t week_idx{ 0 };
-  uint8_t ms_idx{ 0 };
-  uint8_t nsats_idx{ 0 };
-
-  if (!require_field("TimeUS", time_idx)  ||
-      !require_field("GWk",    week_idx)  ||
-      !require_field("GMS",    ms_idx)    ||
-      !require_field("NSats",  nsats_idx))
+  const auto field_indices = resolve_gps_field_indices(field_name2idx);
+  if (!field_indices)
   {
     return;
   }
 
-  // Extract the actual vectors of logged data points
-  const auto& time_vec  = first_gps_instance.at(time_idx).second;
-  const auto& week_vec  = first_gps_instance.at(week_idx).second;
-  const auto& ms_vec    = first_gps_instance.at(ms_idx).second;
-  const auto& nsats_vec = first_gps_instance.at(nsats_idx).second;
+  const auto& time_vec  = first_gps_instance.at(field_indices->time_idx).second;
+  const auto& week_vec  = first_gps_instance.at(field_indices->week_idx).second;
+  const auto& ms_vec    = first_gps_instance.at(field_indices->ms_idx).second;
+  const auto& nsats_vec = first_gps_instance.at(field_indices->nsats_idx).second;
 
-  // DEBUG: confirm units of time_vec before trusting any conversion assumption.
-  // If these print as small fractional numbers (e.g. 45.231), TimeUS is already
-  // in seconds after apply_multipliers() ran. If they print as huge raw integers
-  // (e.g. 45231000), TimeUS is still in microseconds at this point.
-  if (!time_vec.empty())
-  {
-    std::printf("DEBUG: raw time_vec.front()=%.6f time_vec.back()=%.6f\n",
-                time_vec.front(), time_vec.back());
-  }
+  const auto valid_sample_idx =
+      find_first_valid_gps_sample(time_vec, week_vec, ms_vec, nsats_vec, MIN_VALID_NSATS);
 
-  size_t valid_sample_idx = 0;
-  bool found_valid_fix = false;
-
-  // Loop THROUGH THE TIMELINE of logged GPS samples
-  for (size_t i = 0; i < time_vec.size(); ++i)
-  {
-    if (i < nsats_vec.size() && i < week_vec.size() && i < ms_vec.size() &&
-        nsats_vec[i] >= MIN_VALID_NSATS &&   // relaxed to >=
-        time_vec[i]  != 0.0 &&               // added missing check
-        week_vec[i]  > 0.0 &&
-        ms_vec[i]    > 0.0)
-    {
-      valid_sample_idx = i;
-      found_valid_fix = true;
-      break;
-    }
-  }
-
-  if (!found_valid_fix)
+  if (!valid_sample_idx)
   {
     std::printf("Skipping timesync because no sequential GPS sample with a valid fix was found\n");
     return;
   }
 
-  // Extract values at the valid chronological index found
-  const double gps_week    = week_vec[valid_sample_idx];
-  const double gps_week_ms = ms_vec[valid_sample_idx];
+  const double gps_week    = week_vec[*valid_sample_idx];
+  const double gps_week_ms = ms_vec[*valid_sample_idx];
 
-  // TimeUS is already in SECONDS by this point, because apply_multipliers()
-  // runs before apply_timesync() and rescales TimeUS using its FMTU multiplier
-  // (commonly 0.000001, converting raw microseconds to seconds). Dividing by
-  // 1e6 again here was the bug that collapsed the whole log into a
-  // sub-one-second time range.
-  const double log_time_sec = time_vec[valid_sample_idx];
+  const double log_time_sec = time_vec[*valid_sample_idx];
 
-  // Get Unix time directly in SECONDS (e.g., 1750692063.6)
-  const double unix_time_sec = gps_to_unix_time(gps_week, gps_week_ms);
-
-  // Calculate offset purely in SECONDS
+  const double unix_time_sec   = gps_to_unix_time(gps_week, gps_week_ms);
   const double time_offset_sec = unix_time_sec - log_time_sec;
 
-  std::printf("DEBUG: idx=%zu gps_week=%.3f gps_week_ms=%.3f log_time_sec=%.6f unix_time_sec=%.3f offset=%.3f\n",
-              valid_sample_idx, gps_week, gps_week_ms, log_time_sec, unix_time_sec, time_offset_sec);
-
-  // Apply the offset to every message's TimeUS vector (already in seconds)
-  for (auto& [msg_name, instances_map] : messages_map)
-  {
-    const auto msg_fields_it = field_name2idx.find(msg_name);
-    if (msg_fields_it == field_name2idx.end())
-    {
-      continue;
-    }
-
-    const auto time_idx_it = msg_fields_it->second.find("TimeUS");
-    if (time_idx_it == msg_fields_it->second.end())
-    {
-      continue;
-    }
-    const auto& msg_time_idx = time_idx_it->second;
-
-    for (auto& [instance_id, msg_data] : instances_map)
-    {
-      std::vector<double>& timestamps = msg_data[msg_time_idx].second;
-
-      // No conversion needed here anymore — just shift by the computed offset
-      std::transform(timestamps.begin(), timestamps.end(), timestamps.begin(),
-                      [time_offset_sec](double t) { return t + time_offset_sec; });
-    }
-  }
+  shift_all_timestamps(messages_map, field_name2idx, time_offset_sec);
 }

--- a/DataLoadAPBin/dataload_apbin.h
+++ b/DataLoadAPBin/dataload_apbin.h
@@ -107,4 +107,6 @@ private:
 
   // apply time synchronization to the messages_map
   void apply_timesync(void);
+
+  static double gps_to_unix_time(double gps_week, double gps_ms_of_week);
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG PJ_TAG=3.9.2
 # Install dependencies.
 ###############################################################################
 # General dependencies.
-RUN apt update && apt install -y build-essential cmake git 
+RUN apt update && apt install -y build-essential cmake git
 # PlotJuggler dependencies.
 RUN apt update && apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev \
     libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq3-dev \
@@ -21,7 +21,7 @@ RUN git clone --depth 1 --branch ${PJ_TAG} https://github.com/facontidavide/Plot
 # Build PlotJuggler. This will take a long time.
 WORKDIR /plotjuggler_ws
 RUN cmake -S src/PlotJuggler -B build/PlotJuggler -DCMAKE_INSTALL_PREFIX=install \
-    && cmake --build build/PlotJuggler --config RelWithDebInfo --target install
+    && cmake --build build/PlotJuggler --config RelWithDebInfo --target install -j"$(nproc)"
 
 ###############################################################################
 # Compile the plugin
@@ -31,7 +31,7 @@ ARG ADD_UNITS=OFF
 COPY --link . /apbin_plugin
 WORKDIR /apbin_plugin/build
 # Ensure a fresh build folder
-RUN rm -R * \
+RUN rm -Rf * \
     && cmake -Dplotjuggler_DIR="/plotjuggler_ws/install/lib/cmake/plotjuggler" -DADD_UNITS=${ADD_UNITS} .. \
     && make \
     && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE=ubuntu:22.04
-FROM ${BASE_IMAGE} AS build-stage
+FROM ubuntu:22.04 AS build-stage
 
 ARG PJ_TAG=3.9.2
 
@@ -29,18 +28,16 @@ RUN cmake -S src/PlotJuggler -B build/PlotJuggler -DCMAKE_INSTALL_PREFIX=install
 ARG ADD_UNITS=OFF
 
 COPY --link . /apbin_plugin
+
 WORKDIR /apbin_plugin/build
 # Ensure a fresh build folder
 RUN rm -Rf * \
     && cmake -Dplotjuggler_DIR="/plotjuggler_ws/install/lib/cmake/plotjuggler" -DADD_UNITS=${ADD_UNITS} .. \
-    && make \
+    && make -j"$(nproc)" \
     && make install \
     && mkdir /artifacts \
     && cp libDataAPBin.so /artifacts
 
-###############################################################################
-# Export the plugin
-###############################################################################
 FROM scratch AS export-stage
 # Move the plugin to a fresh filesystem that can be exported easily.
 COPY --from=build-stage /artifacts /


### PR DESCRIPTION
Hey,
I added that the plugin uses the first valid GPS and not only the first GPS message in the log.
Had this problem recently that the Pixhawk booted up without GPS signal right after boot and then the log time sync didn't worked.

Changes:
- Added GPS time sync to the first valid GPS message instead of just the first message in the log
- speed up the windows compilation process to multi process compilation
- fixed windows compilation image. windows-latest was updated.
